### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "mocha": "^3.0.0",
     "moment": "^2.14.1",
     "morgan": "^1.7.0",
-    "node-uuid": "^1.4.3",
     "numeral": "^1.5.3",
     "ok-selector": "^1.1.0",
     "peerjs": "^0.3.14",
@@ -184,6 +183,7 @@
     "the-great-mutator": "^1.0.2",
     "through2": "^2.0.1",
     "useragent": "^2.1.7",
+    "uuid": "^3.0.0",
     "x-xss-protection": "^1.0.0"
   },
   "devDependencies": {

--- a/src/core/shared/uuid.js
+++ b/src/core/shared/uuid.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports = {
   type: 'UUID',

--- a/src/util/database.js
+++ b/src/util/database.js
@@ -3,7 +3,7 @@
 var Bluebird = require('bluebird');
 var cradle = Bluebird.promisifyAll(require('cradle'));
 var logger = require('../logging/server/logger').logger;
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import config from './config';
 const { clone } = require('./fast-clone');
 

--- a/src/util/workflow/new-save.js
+++ b/src/util/workflow/new-save.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var saveCommon = require('../workflow/save-common');
 var kickstartPromiseChain = require('../workflow/promise').kickstartPromiseChain;
 import {hostname} from '../../util/hostname';

--- a/tests/integration/routes/server/save-routes-tests.js
+++ b/tests/integration/routes/server/save-routes-tests.js
@@ -65,7 +65,7 @@ describe('save routes', () => {
       new Bluebird(function(resolve) {resolve(undefined);})
     );
 
-    uuid = require('node-uuid');
+    uuid = require('uuid');
     sinon.stub(uuid, 'v4').returns('34242-324324');
 
     var routes = makeTestible('routes/server/save-routes', {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.